### PR TITLE
Feature/sync chat orientation menu ingame

### DIFF
--- a/Chat/ChatConfig.cs
+++ b/Chat/ChatConfig.cs
@@ -1,13 +1,7 @@
-﻿using ChatCore;
-using ChatCore.Config;
-using ChatCore.Models;
+﻿using ChatCore.Config;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace EnhancedStreamChat.Chat
@@ -66,6 +60,8 @@ namespace EnhancedStreamChat.Chat
         public float FontSize = 3.4f;
         [ConfigMeta(Comment = "Allow movement of the chat")]
         public bool AllowMovement = false;
+        [ConfigMeta(Comment = "Sync positions and rotations for the chat in menu and in-game")]
+        public bool SyncOrientation = false;
         [ConfigMeta(Comment = "Reverse the order of the chat")]
         public bool ReverseChatOrder = false;
 

--- a/Chat/ChatDisplay.Settings.cs
+++ b/Chat/ChatDisplay.Settings.cs
@@ -2,12 +2,7 @@
 using BeatSaberMarkupLanguage.Components.Settings;
 using BeatSaberMarkupLanguage.Parser;
 using BeatSaberMarkupLanguage.ViewControllers;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -179,14 +174,16 @@ namespace EnhancedStreamChat.Chat
             get => _isInGame ? _chatConfig.Song_ChatPosition : _chatConfig.Menu_ChatPosition;
             set
             {
-                if (_isInGame)
+                if (_isInGame || SyncOrientation)
                 {
                     _chatConfig.Song_ChatPosition = value;
                 }
-                else
+
+                if (!_isInGame || SyncOrientation)
                 {
                     _chatConfig.Menu_ChatPosition = value;
                 }
+
                 _chatScreen.ScreenPosition = value;
                 NotifyPropertyChanged();
             }
@@ -198,14 +195,16 @@ namespace EnhancedStreamChat.Chat
             get => _isInGame ? _chatConfig.Song_ChatRotation : _chatConfig.Menu_ChatRotation;
             set
             {
-                if (_isInGame)
+                if (_isInGame || SyncOrientation)
                 {
                     _chatConfig.Song_ChatRotation = value;
                 }
-                else
+
+                if (!_isInGame || SyncOrientation)
                 {
                     _chatConfig.Menu_ChatRotation = value;
                 }
+
                 _chatScreen.ScreenRotation = Quaternion.Euler(value);
                 NotifyPropertyChanged();
             }
@@ -219,6 +218,24 @@ namespace EnhancedStreamChat.Chat
             {
                 _chatConfig.AllowMovement = value;
                 _chatScreen.ShowHandle = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        [UIValue("sync-orientation")]
+        public bool SyncOrientation
+        {
+            get => _chatConfig.SyncOrientation;
+            set
+            {
+                _chatConfig.SyncOrientation = value;
+
+                if (value)
+                {
+                    ChatPosition = ChatPosition;
+                    ChatRotation = ChatRotation;
+                }
+
                 NotifyPropertyChanged();
             }
         }

--- a/Chat/ChatDisplay.bsml
+++ b/Chat/ChatDisplay.bsml
@@ -12,6 +12,7 @@
       <tab tags ='settings-tab' tab-name='Layout'>
         <vertical pad='10' pad-top='5' child-control-height='false' child-expand-height='false' child-align='UpperCenter' pref-width='~settings-width'>
           <bool-setting text='Allow Movement' pref-height='6' value='allow-movement' apply-on-change='true'></bool-setting>
+          <bool-setting text='Same position in-game/menu' hover-hint='This setting makes it possible to set the position (and rotation) of the chat for both in-game as menu at the same time.' pref-height='6' value='sync-orientation' apply-on-change='true'/>
           <bool-setting text='Reverse Chat Order' pref-height='6' value='reverse-chat-order' apply-on-change='true'></bool-setting>
           <slider-setting text='Chat Width' min='5' max='1000' increment='5' pref-height='6' value='chat-width' apply-on-change='true' integer-only='true'></slider-setting>
           <slider-setting text='Chat Height' min='5' max='1000' increment='5' pref-height='6' value='chat-height' apply-on-change='true' integer-only='true'></slider-setting>


### PR DESCRIPTION
This PR makes it possible to set the position and rotation of the chat for both the menu and in-game at the same time.
When the option gets enabled (it's disabled by default), it will also sync the position and rotation of the chat.
Eg:
When in the menu and the option gets enabled, it will also copy the current position and rotation of the menu chat to the ingame chat. The same happens in the other way around.