### PR TITLE
Update manifest to include BSIPA dependency

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,17 @@
 ﻿{
-  "$schema": "https://raw.githubusercontent.com/nike4613/ModSaber-MetadataFileSchema/master/Schema.json",
-  "id": "Enhanced Stream Chat",
+  "$schema": "https://raw.githubusercontent.com/bsmg/BSIPA-MetadataFileSchema/master/Schema.json",
+  "id": "Enhanced-Stream-Chat",
   "name": "Enhanced Stream Chat",
   "author": "brian91292",
   "version": "3.0.0-rc5",
   "description": "Enhanced Stream Chat is a rich text chat integration mod, with full unicode, emote, and emoji support.",
   "gameVersion": "1.9.0",
   "dependsOn": {
+    "BSIPA": "^4.0.5",
     "BeatSaberMarkupLanguage": "^1.3.1",
     "BS Utils": "^1.4.8",
     "ChatCore": "^1.0.0-rc5"
   },
-  "features": [
-  ],
   "links": {
     "project-home": "https://github.com/brian91292/EnhancedStreamChat-v3",
     "donate": "https://ko-fi.com/brian91292"


### PR DESCRIPTION
The next version of BSIPA will require that it is listed as a dependency for all mods.

Also the `id` field did not like the spaces and the `features` array was obsolete.